### PR TITLE
Implement core UI skeleton

### DIFF
--- a/Snap Meal/Models.swift
+++ b/Snap Meal/Models.swift
@@ -1,0 +1,18 @@
+import Foundation
+import SwiftUI
+
+struct Meal: Identifiable, Codable {
+    enum MealTime: String, Codable, CaseIterable {
+        case breakfast = "朝"
+        case lunch = "昼"
+        case dinner = "夜"
+    }
+
+    var id = UUID()
+    var photo: UIImage?
+    var time: MealTime
+    var carbs: Double?
+    var calories: Double?
+    var protein: Double?
+    var notes: String?
+}

--- a/Snap Meal/Snap_MealApp.swift
+++ b/Snap Meal/Snap_MealApp.swift
@@ -25,7 +25,7 @@ struct Snap_MealApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            CameraView()
         }
         .modelContainer(sharedModelContainer)
     }

--- a/Snap Meal/Views/CameraPreviewView.swift
+++ b/Snap Meal/Views/CameraPreviewView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import AVFoundation
+
+struct CameraPreviewView: UIViewRepresentable {
+    @Binding var image: UIImage?
+    let session = AVCaptureSession()
+    let output = AVCapturePhotoOutput()
+    let queue = DispatchQueue(label: "camera.queue")
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView(frame: .zero)
+        configureSession()
+        let previewLayer = AVCaptureVideoPreviewLayer(session: session)
+        previewLayer.videoGravity = .resizeAspectFill
+        previewLayer.frame = UIScreen.main.bounds
+        view.layer.addSublayer(previewLayer)
+        session.startRunning()
+        NotificationCenter.default.addObserver(forName: .capturePhoto, object: nil, queue: .main) { _ in
+            let settings = AVCapturePhotoSettings()
+            output.capturePhoto(with: settings, delegate: context.coordinator)
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+
+    func configureSession() {
+        session.beginConfiguration()
+        guard let device = AVCaptureDevice.default(for: .video),
+              let input = try? AVCaptureDeviceInput(device: device) else { return }
+        if session.canAddInput(input) { session.addInput(input) }
+        if session.canAddOutput(output) { session.addOutput(output) }
+        session.commitConfiguration()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, AVCapturePhotoCaptureDelegate {
+        let parent: CameraPreviewView
+        init(_ parent: CameraPreviewView) { self.parent = parent }
+
+        func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+            if let data = photo.fileDataRepresentation(), let uiImage = UIImage(data: data) {
+                parent.image = uiImage
+                NotificationCenter.default.post(name: .photoCaptured, object: uiImage)
+            }
+        }
+    }
+}

--- a/Snap Meal/Views/CameraView.swift
+++ b/Snap Meal/Views/CameraView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import AVFoundation
+
+struct CameraView: View {
+    @State private var showPreview = false
+    @State private var capturedImage: UIImage?
+    @State private var showSettings = false
+
+    var body: some View {
+        ZStack {
+            CameraPreviewView(image: $capturedImage)
+                .ignoresSafeArea()
+            VStack {
+                HStack {
+                    Spacer()
+                    Button(action: { showSettings.toggle() }) {
+                        Image(systemName: "gearshape")
+                            .font(.title2)
+                            .padding()
+                    }
+                    .sheet(isPresented: $showSettings) {
+                        SettingsView()
+                    }
+                }
+                Spacer()
+                Button(action: {
+                    // Capture
+                    NotificationCenter.default.post(name: .capturePhoto, object: nil)
+                }) {
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: 72, height: 72)
+                        .shadow(radius: 4)
+                }
+                .padding(.bottom, 40)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .photoCaptured)) { notification in
+            if let image = notification.object as? UIImage {
+                capturedImage = image
+                showPreview = true
+            }
+        }
+        .fullScreenCover(isPresented: $showPreview) {
+            if let img = capturedImage {
+                PreviewView(image: img)
+            }
+        }
+    }
+}
+
+extension Notification.Name {
+    static let capturePhoto = Notification.Name("capturePhoto")
+    static let photoCaptured = Notification.Name("photoCaptured")
+}

--- a/Snap Meal/Views/CompletionView.swift
+++ b/Snap Meal/Views/CompletionView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct CompletionView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "checkmark.circle.fill")
+                .resizable()
+                .frame(width: 80, height: 80)
+                .foregroundColor(.green)
+            Text("登録が完了しました")
+                .font(.title)
+            HStack {
+                Button("履歴を見る") {
+                    // show history
+                }
+                .padding()
+                Button("もう一度撮る") {
+                    dismiss()
+                }
+                .padding()
+            }
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                dismiss()
+            }
+        }
+    }
+}

--- a/Snap Meal/Views/HistoryView.swift
+++ b/Snap Meal/Views/HistoryView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct HistoryView: View {
+    var meals: [Meal] = []
+
+    var body: some View {
+        List(meals) { meal in
+            HStack {
+                if let photo = meal.photo {
+                    Image(uiImage: photo)
+                        .resizable()
+                        .frame(width: 50, height: 50)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                VStack(alignment: .leading) {
+                    Text(meal.time.rawValue)
+                        .font(.headline)
+                    if let cals = meal.calories {
+                        Text("\(cals, specifier: "%.0f") kcal")
+                    }
+                }
+            }
+        }
+        .navigationTitle("履歴")
+    }
+}

--- a/Snap Meal/Views/PreviewView.swift
+++ b/Snap Meal/Views/PreviewView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct PreviewView: View {
+    let image: UIImage
+    @State private var selectedTime: Meal.MealTime = .breakfast
+    @State private var showCompletion = false
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxHeight: UIScreen.main.bounds.height / 2)
+            Picker("食事の時間帯", selection: $selectedTime) {
+                ForEach(Meal.MealTime.allCases, id: \.self) { time in
+                    Text(time.rawValue).tag(time)
+                }
+            }
+            .pickerStyle(.segmented)
+            Spacer()
+            HStack {
+                Button("撮り直し") {
+                    dismiss()
+                }
+                .padding()
+                Spacer()
+                Button("保存") {
+                    showCompletion = true
+                }
+                .padding()
+            }
+        }
+        .padding()
+        .fullScreenCover(isPresented: $showCompletion) {
+            CompletionView()
+        }
+    }
+}

--- a/Snap Meal/Views/SettingsView.swift
+++ b/Snap Meal/Views/SettingsView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var healthKitEnabled = true
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Toggle("HealthKit連携", isOn: $healthKitEnabled)
+                NavigationLink("プライバシーポリシー") {
+                    Text("プライバシーポリシー")
+                }
+                HStack {
+                    Text("バージョン")
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                }
+            }
+            .navigationTitle("設定")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set `CameraView` as main entry point
- add basic models
- implement `CameraView` and `CameraPreviewView` for capturing photos
- add preview, completion, history, and settings screens

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6872a90aab488327928437afaf36aeed